### PR TITLE
Fix typo in BrussScaling.jl

### DIFF
--- a/script/AutomaticDifferentiation/BrussScaling.jl
+++ b/script/AutomaticDifferentiation/BrussScaling.jl
@@ -239,8 +239,8 @@ csa = map(csan) do n
     @info "Running $alg"
     f = SciMLSensitivity.alg_autodiff(alg) ? bfun : ODEFunction(bfun, jac=brusselator_jac)
     solver = Rodas5(autodiff=false)
-    @time diffeq_sen_l2(bfun, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
-    t = @elapsed diffeq_sen_l2(bfun, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
+    @time diffeq_sen_l2(f, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
+    t = @elapsed diffeq_sen_l2(f, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
     return t
   end
   @show n,ts
@@ -289,8 +289,8 @@ csavjp = map(csan) do n
     @info "Running $alg"
     f = SciMLSensitivity.alg_autodiff(alg) ? bfun : ODEFunction(bfun, jac=brusselator_jac)
     solver = Rodas5(autodiff=false)
-    @time diffeq_sen_l2(bfun, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
-    t = @elapsed diffeq_sen_l2(bfun, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
+    @time diffeq_sen_l2(f, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
+    t = @elapsed diffeq_sen_l2(f, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
     return t
   end
   @show n,ts


### PR DESCRIPTION
Function f was not used and because of that user-defined brusselator_jac was not used either, which yielded misleading results.