### PR TITLE
Fix Documenter minimum version bound: 0.27 -> 1.16

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,5 +7,5 @@ version = "1.0.0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "0.27"
+Documenter = "1.16"
 julia = "1.6"


### PR DESCRIPTION
## Summary

- Updated Documenter minimum version bound from `0.27` to `1.16` in root `Project.toml`

## Problem

The root `Project.toml` had `Documenter = "0.27"` while `docs/Project.toml` requires `Documenter = "1.16.1"`. This inconsistency meant:
- The package's declared minimum Documenter version (0.27) was significantly lower than what the documentation build actually requires (1.16.1)
- Documenter 1.x is a major version with API changes from 0.27.x

## Fix

Aligned the root `Project.toml` Documenter bound to `1.16` to match the documentation requirements.

## Evidence

- `docs/Project.toml` line 5: `Documenter = "1.16.1"`
- `docs/make.jl` uses `Documenter.HTML()` with options like `canonical` that are standard across Documenter versions
- The package itself (`src/SciMLBenchmarksOutput.jl`) is an empty module - Documenter is only used for documentation builds

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)