### PR TITLE
Add NeuralNetworks folder and register in docs

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -73,6 +73,7 @@ section_titles = [
     "MethodOfLinesPDE" => "MethodOfLines.jl Partial Differential Equation (PDE) Formulations",
     "PINNErrorsVsTime" => "Physics-Informed Neural Network (Neural Network PDE Solver) Cost Function Benchmarks",
     "PINNOptimizers" => "Physics-Informed Neural Network (Neural Network PDE Solver) Optimizer Benchmarks",
+    "NeuralNetworks" => "Neural Network Framework Benchmarks",
     "AdaptiveSDE" => "SDE Adaptivity Benchmarks",
     "Surrogates" => "Surrogate Benchmarks",
     "Symbolics" => "Symbolic Manipulation Benchmarks"


### PR DESCRIPTION
## Summary

- Add placeholder directory structure for the new NeuralNetworks benchmark across all output formats (markdown, html, notebook, pdf, script)
- Register "NeuralNetworks" section in `docs/pages.jl` as "Neural Network Framework Benchmarks"

This prepares the output repo for SciML/SciMLBenchmarks.jl#1530, which adds benchmarks comparing Lux, Flux, SimpleChains, Reactant, JAX, and PyTorch on common neural network workloads.

## Test plan

- [ ] Verify docs build succeeds with the new section registered
- [ ] Confirm CI publish step can write to the new directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)