### PR TITLE
List the Turing.jl AD benchmark under a proper section title

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -49,6 +49,7 @@ section_titles = [
     "NonlinearProblem" => "Nonlinear Solvers",
     "AutomaticDifferentiation" => "Automatic Differentiation",
     "AutomaticDifferentiationSparse" => "Sparse Automatic Differentiation",
+    "AutomaticDifferentiationTuring" => "Turing.jl Automatic Differentiation",
     "NonStiffODE" => "Non-Stiff Ordinary Differential Equations (ODEs)",
     "StiffODE" => "Stiff Ordinary Differential Equations (ODEs)",
     "Bio" => "Biological Differential Equations",


### PR DESCRIPTION
> **Please ignore this PR until it has been reviewed by @ChrisRackauckas.** Opened as a draft.

Companion to SciML/SciMLBenchmarks.jl#1624, which adds a `benchmarks/AutomaticDifferentiationTuring` folder (a port of [TuringLang/ADTests](https://github.com/TuringLang/ADTests)).

`docs/pages.jl` builds the sidebar from `section_titles`, and anything not listed there falls through to the alphabetical fallback at the bottom of the file. Without an entry, the new folder shows up in the sidebar as the raw folder name `AutomaticDifferentiationTuring`, sorted below every titled section. This adds the title next to the other two AD sections.

Verified by running `docs/pages.jl` against a tree containing the built markdown. Before:

```
SciMLBenchmarks.jl: Benchmarks for Scientific Machine Learning (SciML) and Equation Solvers
Automatic Differentiation
Sparse Automatic Differentiation
Non-Stiff Ordinary Differential Equations (ODEs)
AutomaticDifferentiationTuring          <- fallback, raw folder name, at the end
```

After:

```
"Turing.jl Automatic Differentiation" => Any["Turing.jl Model AD Backend Comparison" => "AutomaticDifferentiationTuring/TuringADTests.md"]
```

positioned directly after `Sparse Automatic Differentiation`.

The equivalent line is already in `docs/pages.jl` on SciML/SciMLBenchmarks.jl#1624, so `publish_benchmark_output.sh` would eventually copy it here on the next master publish. This PR is so the two copies do not drift in the meantime, and so the listing is right the first time the benchmark output lands.

Note that this change is inert until the `markdown/AutomaticDifferentiationTuring/` content is published here by the benchmark CI — `pages.jl` only uses a `section_titles` entry when the corresponding folder exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8qBZzvd4yxfDYs7v8WDqE
