### PR TITLE
pages.jl: add LinearSolveGPU section

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -45,6 +45,7 @@ end
 section_titles = [
     "MultiLanguage" => "Multi-Language Wrapper Benchmarks",
     "LinearSolve" => "Linear Solvers",
+    "LinearSolveGPU" => "Linear Solvers (GPU)",
     "IntervalNonlinearProblem" => "Interval Rootfinding",
     "NonlinearProblem" => "Nonlinear Solvers",
     "AutomaticDifferentiation" => "Automatic Differentiation",


### PR DESCRIPTION
Mirrors the docs/pages.jl edit from SciML/SciMLBenchmarks.jl#1635, as requested there: adds the LinearSolveGPU folder to the section titles as "Linear Solvers (GPU)", placed after the existing Linear Solvers section.