### PR TITLE
pages.jl: add LinearSolveDistributed section

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -46,6 +46,7 @@ section_titles = [
     "MultiLanguage" => "Multi-Language Wrapper Benchmarks",
     "LinearSolve" => "Linear Solvers",
     "LinearSolveGPU" => "Linear Solvers (GPU)",
+    "LinearSolveDistributed" => "Distributed Linear Solvers (MPI)",
     "IntervalNonlinearProblem" => "Interval Rootfinding",
     "NonlinearProblem" => "Nonlinear Solvers",
     "AutomaticDifferentiation" => "Automatic Differentiation",


### PR DESCRIPTION
Mirrors the docs/pages.jl edit from SciML/SciMLBenchmarks.jl#1636: adds the LinearSolveDistributed folder to the section titles as "Distributed Linear Solvers (MPI)", after the GPU linear solvers section.