### PR TITLE
Fix KdV FDM script parse error

### DIFF
--- a/script/MOLPDE/kdv_fdm_wpd.jl
+++ b/script/MOLPDE/kdv_fdm_wpd.jl
@@ -98,8 +98,10 @@ setups = [Dict(:alg => NorsettEuler(), :dts => 1e-6 * multipliers),
           Dict(:alg => ETDRK2(), :dts => 1e-3 * multipliers),
           Dict(:alg => ETDRK2(krylov=true, m=20), :dts => 1e-2 * multipliers),
           Dict(:alg => ETDRK2(krylov=true, m=20), :dts => 1e-2 * multipliers)]
-labels = hcat("NorsettEuler (caching)", "NorsettEuler (m=5)",# "NorsettEuler (m=20)",
-              "ETDRK2 (caching)", "ETDRK2 (m=5)"), "ETDRK2 (m=20)")
+labels = hcat(
+    "NorsettEuler (caching)", "NorsettEuler (m=5)", # "NorsettEuler (m=20)",
+    "ETDRK2 (caching)", "ETDRK2 (m=5)", "ETDRK2 (m=20)"
+)
 @time wp = WorkPrecisionSet(prob,abstols,reltols,setups;
                             print_names=true, names=labels,
                             numruns=5, error_estimate=:l2,
@@ -197,4 +199,3 @@ plot(wp, label=labels, markershape=:auto, title="Between family, medium order")
 
 using SciMLBenchmarks
 SciMLBenchmarks.bench_footer(WEAVE_ARGS[:folder],WEAVE_ARGS[:file])
-


### PR DESCRIPTION
## What changed and why

Move the closing parenthesis of the KdV FDM benchmark's `labels` call so all five labels belong to `hcat`. The historical generated script has otherwise been unparsable since it was introduced, which causes Runic to abort before it can inspect the repository.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before on `upstream/main` (`3113883c73ee10dc0d688c7f0e15af95c407b489`):

```text
$ git show upstream/main:script/MOLPDE/kdv_fdm_wpd.jl | julia +1.12 -m Runic --check --lines=101:104 --stdin-filename=script/MOLPDE/kdv_fdm_wpd.jl -
ERROR: failed to parse input from script/MOLPDE/kdv_fdm_wpd.jl: ParseError:
# Error @ script/MOLPDE/kdv_fdm_wpd.jl:103:67
labels = hcat("NorsettEuler (caching)", "NorsettEuler (m=5)",# "NorsettEuler (m=20)",
              "ETDRK2 (caching)", "ETDRK2 (m=5)"), "ETDRK2 (m=20)")
#                                                                 ╙ ── extra tokens after end of expression
[exit 1]
```

Passing after on this branch:

```text
$ git show HEAD:script/MOLPDE/kdv_fdm_wpd.jl | julia +1.12 -m Runic --check --lines=101:104 --stdin-filename=script/MOLPDE/kdv_fdm_wpd.jl -
[no output; exit 0]

$ julia +1.12 -e 'Meta.parseall(read(ARGS[1], String); filename=ARGS[1]); println("parse: ok")' script/MOLPDE/kdv_fdm_wpd.jl
parse: ok

$ git diff --check upstream/main...HEAD
[no output; exit 0]

$ git diff upstream/main...HEAD | typos -
[no output; exit 0]
```

Runic 1.9.0 on Julia 1.12.7 was used. A repository-wide `julia +1.12 -m Runic --check .` now completes without a parse diagnostic, but still exits 1 because historical generated scripts contain unrelated formatting drift; this PR deliberately does not apply a whole-tree formatting sweep. There is no package test suite in this output repository. The docs build was not run because no docs, docstrings, or public API changed.

## Bisect

A parser-specific `git bisect run` from the parent of the file's first appearance through current `main` identified `9e93d11cf565a7e40ef98fe43b2db1fb4b52232e` as the first bad commit. That 2021 upload introduced `script/MOLPDE/kdv_fdm_wpd.jl` with the malformed expression.

## Links

- Introducing commit: https://github.com/SciML/SciMLBenchmarksOutput/commit/9e93d11cf565a7e40ef98fe43b2db1fb4b52232e
- Current source benchmark with the corrected label-call structure: https://github.com/SciML/SciMLBenchmarks.jl/blob/e80b05363fe9885643d3c9110a5711399e1302d5/benchmarks/SimpleHandwrittenPDE/kdv_fdm_wpd.jmd

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
